### PR TITLE
Fix tests failure on Perl 5.26+ with PERL_USE_UNSAFE_INC=0

### DIFF
--- a/t/Capture.pm
+++ b/t/Capture.pm
@@ -1,4 +1,5 @@
-package t::Capture;
+package # Hide from PAUSE
+  Capture;
 use base qw(Exporter);
 our @EXPORT = qw(capture_out);
 

--- a/t/coderef_args.t
+++ b/t/coderef_args.t
@@ -1,5 +1,6 @@
 use Test::More;
-use t::Capture;
+use lib 't';
+use Capture;
 use CGI::Compile;
 
 my $sub = CGI::Compile->compile("t/args.cgi");

--- a/t/compile.t
+++ b/t/compile.t
@@ -1,6 +1,7 @@
 use Test::More;
 use Test::Requires qw(CGI);
-use t::Capture;
+use lib 't';
+use Capture;
 use CGI::Compile;
 #no warnings 'signal'; # for MSWin32
 

--- a/t/data_end.t
+++ b/t/data_end.t
@@ -1,6 +1,8 @@
 use Test::More;
 use CGI::Compile;
-use t::Capture;
+
+use lib 't';
+use Capture;
 
 {
     my $sub = CGI::Compile->compile("t/data.cgi");

--- a/t/exit.t
+++ b/t/exit.t
@@ -1,8 +1,8 @@
 use strict;
 use Test::More tests => 2;
 use CGI::Compile;
-use t::Capture;
 use lib "t";
+use Capture;
 use Exit;
 
 my $sub = CGI::Compile->compile("t/exit.cgi");

--- a/t/local-SIG.t
+++ b/t/local-SIG.t
@@ -1,6 +1,7 @@
 #!perl
 
-use t::Capture;
+use lib 't';
+use Capture;
 use CGI::Compile;
 use POSIX qw(:signal_h);
 

--- a/t/source.t
+++ b/t/source.t
@@ -1,6 +1,7 @@
 use Test::More;
 use CGI::Compile;
-use t::Capture;
+use lib 't';
+use Capture;
 
 {
     my $str =<<EOL;

--- a/t/source_filter.t
+++ b/t/source_filter.t
@@ -1,6 +1,7 @@
 use Test::More;
 use Test::Requires qw(Switch);
-use t::Capture;
+use lib 't';
+use Capture;
 use CGI::Compile;
 
 my $sub = eval {

--- a/t/warnings.t
+++ b/t/warnings.t
@@ -1,5 +1,6 @@
 use Test::More;
-use t::Capture;
+use lib 't';
+use Capture;
 use CGI::Compile;
 
 my $sub = CGI::Compile->compile("t/warnings.cgi");


### PR DESCRIPTION
Bug: https://github.com/miyagawa/CGI-Compile/issues/21
Bug: https://bugs.gentoo.org/614352